### PR TITLE
Ruby 2.6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ RUN apt-get update && \
 # Install system dependencies
 RUN apt-get update && \
   apt-get install -y curl software-properties-common && \
-  apt-get install -y build-essential libpq-dev ruby2.3 ruby2.3-dev nodejs libmysqlclient-dev exiv2 \
+  apt-get install -y build-essential libpq-dev ruby2.6 ruby2.6-dev nodejs libmysqlclient-dev exiv2 \
   libexiv2-dev imagemagick cmake git pkg-config python libxml2-dev libxslt1-dev \
   libcurl4-openssl-dev mysql-client zipcmp libxrender1 libgeoip-dev unzip zipcmp file vim jhead \
   netcat-openbsd yarn libmaxminddb0 geoipupdate && \


### PR DESCRIPTION
Bump Ruby to 2.6, for deploying on GCP. See https://github.com/4ormat/ey-cloud-recipes/pull/321 for the equivalent on Engine Yard.